### PR TITLE
refactor: factorize glass card styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1144,15 +1144,19 @@ html {
   margin: var(--spacing-xl) 0;
 }
 
+/* Carte vitrée réutilisable */
+.glass-card {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius-lg);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
 .info-card {
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
-  background: rgba(255, 255, 255, 0.1);
   padding: var(--spacing-lg);
-  border-radius: var(--border-radius-lg);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .info-icon {
@@ -1179,11 +1183,7 @@ html {
 /* Section des tâches du projet */
 .project-tasks {
   margin: var(--spacing-xl) 0;
-  background: rgba(255, 255, 255, 0.1);
   padding: var(--spacing-xl);
-  border-radius: var(--border-radius-lg);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .project-tasks h3 {
@@ -2062,29 +2062,14 @@ details[open] summary {
     background: none;
     border: 1px solid var(--color-primary);
   }
-  
-  .info-card {
+
+  .glass-card {
     background: none;
     border: 1px solid var(--color-primary);
     color: var(--color-primary);
   }
-  
-  .info-content h3,
-  .info-content p {
-    color: var(--color-primary);
-  }
-  
-  .project-tasks {
-    background: none;
-    border: 1px solid var(--color-primary);
-    color: var(--color-primary);
-  }
-  
-  .project-tasks h3 {
-    color: var(--color-primary);
-  }
-  
-  .task-list li {
+
+  .glass-card * {
     color: var(--color-primary);
   }
   

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         </p>
         
         <div class="project-info-grid">
-          <div class="info-card">
+          <div class="info-card glass-card">
             <div class="info-icon">
               <i data-lucide="award" class="icon icon-lg"></i>
             </div>
@@ -66,8 +66,8 @@
               <p><strong>20 pts</strong> projet <br> <strong>20 pts</strong> écrit</p>
             </div>
           </div>
-          
-          <div class="info-card">
+
+          <div class="info-card glass-card">
             <div class="info-icon">
               <i data-lucide="clock" class="icon icon-lg"></i>
             </div>
@@ -76,8 +76,8 @@
               <p><strong>9 semaines</strong></p>
             </div>
           </div>
-          
-          <div class="info-card">
+
+          <div class="info-card glass-card">
             <div class="info-icon">
               <i data-lucide="calendar-check" class="icon icon-lg"></i>
             </div>
@@ -88,7 +88,7 @@
           </div>
         </div>
 
-        <div class="project-tasks">
+        <div class="project-tasks glass-card">
           <h3>Ce que tu dois faire :</h3>
           <ul class="task-list">
             <li><i data-lucide="check" class="icon icon-sm"></i> <span>Construire et publier un site en <strong>HTML5 + CSS3</strong></span></li>


### PR DESCRIPTION
## Summary
- add reusable `glass-card` class for glass effect UI
- apply `glass-card` to info cards and task section to remove duplicate CSS
- simplify print styles to target `glass-card`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4369c60f483328e1131271fa0b9f0