### PR TITLE
Planification 2026-2027 (rendu 8 janvier 2027)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ coverage/
 # Temporary folders
 tmp/
 temp/
+# Captures Playwright (ne pas publier sur GitHub Pages)
+playwright/

--- a/index.html
+++ b/index.html
@@ -325,17 +325,15 @@
                         <div class="timeline-marker" aria-hidden="true">
                             <i data-lucide="layers"></i>
                         </div>
-                        <span class="timeline-date"><i data-lucide="calendar" aria-hidden="true"></i> 3–17 septembre 2025</span>
+                        <span class="timeline-date"><i data-lucide="calendar" aria-hidden="true"></i> 19 août – 16 septembre 2026</span>
                         <div class="timeline-card">
                             <h3>Phase 1 — Fondations</h3>
                             <p>Se familiariser avec les outils et poser les bases du projet.</p>
                             <ul>
                                 <li>Création des comptes <strong>GitHub</strong> et <strong>JetBrains</strong></li>
-                                <li>Publication de votre premier "Hello World" sur GitHub Pages</li>
                                 <li>Configuration de votre IDE (WebStorm ou VS Code)</li>
-                                <li>Choix définitif du <strong>sujet</strong> et de la <strong>plateforme
-                                    d'apprentissage</strong></li>
-                                <li>Définition de la <strong>palette de couleurs</strong> et <strong>polices d'écriture</strong></li>
+                                <li>Publication de votre premier "Hello World" sur GitHub Pages</li>
+                                <li>Choix définitif du <strong>sujet</strong> de votre site</li>
                             </ul>
                         </div>
                     </li>
@@ -343,17 +341,22 @@
                         <div class="timeline-marker" aria-hidden="true">
                             <i data-lucide="code-2"></i>
                         </div>
-                        <span class="timeline-date"><i data-lucide="calendar" aria-hidden="true"></i> 17 sept. – 3 déc. 2025</span>
+                        <span class="timeline-date"><i data-lucide="calendar" aria-hidden="true"></i> 16 sept. – 25 nov. 2026</span>
                         <div class="timeline-card">
                             <h3>Phase 2 — Développement</h3>
                             <p>Développement actif avec revue de l'enseignant toutes les deux semaines.</p>
                             <ul>
-                                <li><strong>1er octobre</strong> : Concept validé et structure HTML de base
+                                <li><strong>23 septembre</strong> : <strong>Palette de couleurs</strong> et
+                                    <strong>polices d'écriture</strong> définies
                                 </li>
-                                <li><strong>15 octobre</strong> : HTML complet avec navigation fonctionnelle</li>
-                                <li><strong>5 novembre</strong> : CSS de base et début du responsive design</li>
-                                <li><strong>26 novembre</strong> : Responsive fonctionnel et tests
-                                    multi‑appareils</li>
+                                <li><strong>30 septembre</strong> : Concept validé et structure HTML de base</li>
+                                <li><strong>4 novembre</strong> : HTML complet avec navigation fonctionnelle et CSS de
+                                    base sur tout le site
+                                </li>
+                                <li><strong>18 novembre</strong> : Images optimisées et audit de performance</li>
+                                <li><strong>25 novembre</strong> : Responsive fonctionnel, tests multi‑appareils et
+                                    <a href="https://validator.w3.org/">validation W3C</a>
+                                </li>
                             </ul>
                         </div>
                     </li>
@@ -361,15 +364,20 @@
                         <div class="timeline-marker" aria-hidden="true">
                             <i data-lucide="check-circle-2"></i>
                         </div>
-                        <span class="timeline-date"><i data-lucide="calendar-check" aria-hidden="true"></i> 10 déc. 2025 – 9 janv. 2026</span>
+                        <span class="timeline-date"><i data-lucide="calendar-check" aria-hidden="true"></i> 26 nov. 2026 – 8 janv. 2027</span>
                         <div class="timeline-card">
                             <h3>Phase 3 — Finalisation</h3>
                             <p>Finalisation et optimisations avant livraison.</p>
                             <ul>
-                                <li><strong>17 décembre – Optimisation</strong> : <a href="https://validator.w3.org/">Validation W3C</a>, optimisation des
-                                    images, audits de performance
+                                <li><strong>23 décembre – Dernière séance</strong> : Checklist finale passée en classe,
+                                    derniers réglages
                                 </li>
-                                <li><strong>9 janvier 2026 – Livraison finale</strong> : Site publié et README complet</li>
+                                <li><strong>Vacances</strong> : Ce qui n'est pas terminé le 23 décembre devra l'être
+                                    pendant les vacances
+                                </li>
+                                <li><strong>Vendredi 8 janvier 2027 – Livraison finale</strong> : Site en ligne, dépôt
+                                    et README complets
+                                </li>
                             </ul>
                         </div>
                     </li>
@@ -837,7 +845,7 @@
     </main>
 
     <footer class="mini-footer">
-        <p>&copy; 2025 ESIG - Module 113. Tous droits réservés.</p>
+        <p>&copy; 2026 ESIG - Module 113. Tous droits réservés.</p>
         <p>Made with <i data-lucide="heart" class="icon icon-lg" aria-hidden="true"></i> by <a href="mailto:steve.fallet@divcom.ch">Steve Fallet</a></p>
 
         <img src="img/formateur-devant-tableau.webp" alt="Formateur devant un tableau">


### PR DESCRIPTION
Met à jour la timeline du site des consignes pour l'année 2026-2027.

## Nouvelle planification

| Phase | Période | Jalons |
|---|---|---|
| 1 — Fondations | 19 août – 16 sept. 2026 | Comptes, IDE, Hello World en ligne, choix du sujet |
| 2 — Développement | 16 sept. – 25 nov. 2026 | Palette 23.09 · structure HTML 30.09 · HTML+CSS complets 04.11 · images 18.11 · responsive + W3C 25.11 |
| 3 — Finalisation | 26 nov. 2026 – 8 janv. 2027 | Dernière séance 23.12 · **livraison vendredi 8 janvier 2027** |

## Deux déplacements par rapport à 2025-2026

- Le choix de la **palette et des polices** passe de la phase 1 à la phase 2 (séance 6) — les élèves n'ont pas encore vu CSS avant.
- La **validation W3C** passe de la phase 3 à la phase 2 (séance 13), où elle est enseignée.

Un point est explicité : le rendu tombe après les vacances, donc ce qui n'est pas terminé le 23 décembre devra l'être pendant les vacances.

## Hypothèse

Les jalons sont repris du plan d'enseignement 2026-2027 publié sur devjs.ch (fallinov/2025-sfa-devjs#65) — à réajuster si le plan évolue.

## Vérifications

Rendu contrôlé en local (desktop 1280 et mobile 390), console navigateur sans erreur ni warning. `playwright/` ajouté au `.gitignore` car la racine du dépôt est publiée telle quelle par GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)