### PR TITLE
chore: migration email vers steve.fallet@edu.jura.ch

### DIFF
--- a/index.html
+++ b/index.html
@@ -846,7 +846,7 @@
 
     <footer class="mini-footer">
         <p>&copy; 2026 ESIG - Module 113. Tous droits réservés.</p>
-        <p>Made with <i data-lucide="heart" class="icon icon-lg" aria-hidden="true"></i> by <a href="mailto:steve.fallet@divcom.ch">Steve Fallet</a></p>
+        <p>Made with <i data-lucide="heart" class="icon icon-lg" aria-hidden="true"></i> by <a href="mailto:steve.fallet@edu.jura.ch">Steve Fallet</a></p>
 
         <img src="img/formateur-devant-tableau.webp" alt="Formateur devant un tableau">
     </footer>


### PR DESCRIPTION
Nouveau tenant DIVCOM (`edu.jura.ch`) actif depuis le 17 août 2026. L'ancienne adresse `@divcom.ch` reste active 3-4 mois.

Un seul changement : le `mailto:` du footer (`index.html:849`).

Le logo `img/divcom-logo.png` est laissé tel quel — DIVCOM reste le nom de la division, seul le tenant email change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg7vPsqDJ4wALSDDjDZkRL